### PR TITLE
Lint fixes, magic number removal, automatic fns, etc.

### DIFF
--- a/rtl/sata_reset.v
+++ b/rtl/sata_reset.v
@@ -86,8 +86,8 @@ module	sata_reset #(
 				HR_AWAIT_RXCOMWAKE	= 4'h6,
 				HR_AWAIT_RXCLRWAKE	= 4'h7,
 				HR_AWAIT_ALIGN		= 4'h8,
-				HR_SEND_ALIGN		= 4'h9,
-				HR_READY			= 4'ha,
+				// HR_SEND_ALIGN	= 4'h9,
+				HR_READY		= 4'ha,
 				HR_AWAIT_RXCLRINIT	= 4'hb;
 
 	// Watchdog wait time is given in SATA chap 8, OOB and PHY POWER STATES.
@@ -109,7 +109,10 @@ module	sata_reset #(
 	reg	[3:0]	fsm_state;
 
 	wire		w_rx_align, rx_align;
+	// FIXME--these should be used for ... something
+	// Verilator lint_off UNUSED
 	wire		w_rx_sync, rx_sync;
+	// Verilator lint_on  UNUSED
 	reg				retry_timeout;
 	reg	[LGWATCHDOG-1:0]	watchdog_counter;
 
@@ -430,5 +433,13 @@ module	sata_reset #(
 		min_alignment_counter <= min_alignment_counter - 1;
 		check_alignment <= (min_alignment_counter <= 1);
 	end
+	// }}}
+
+	// Keep Verilator happy
+	// {{{
+	// Verilator lint_off UNUSED
+	wire	unused;
+	assign	unused = &{ 1'b0, ck_rx_cdrlock };
+	// Verilator lint_on  UNUSED
 	// }}}
 endmodule

--- a/rtl/sata_transport.v
+++ b/rtl/sata_transport.v
@@ -82,7 +82,7 @@ module	sata_transport #(
 		//
 		input	wire		i_dma_stall,
 		input	wire		i_dma_ack,
-		input	wire	[31:0]	i_dma_data,
+		input	wire [DW-1:0]	i_dma_data,
 		input	wire		i_dma_err,
 		// }}}
 		output	wire		o_int,
@@ -196,11 +196,11 @@ module	sata_transport #(
 	// Reset CDC
 	// {{{
 
-	always @(posedge i_phy_clk or i_reset)	// I made this change for simulation
-	if (!i_reset)
+	always @(posedge i_phy_clk or posedge i_reset)
+	if (i_reset)
 		{ phy_reset_n, phy_reset_xpipe } <= -1;
 	else
-		{ phy_reset_n, phy_reset_xpipe } <= 0;
+		{ phy_reset_n, phy_reset_xpipe } <= { phy_reset_xpipe, 1'b0 };
 
 	assign	rxdma_reset = !(s2mm_core_request || s2mm_core_busy);
 	always @(posedge i_phy_clk)
@@ -605,6 +605,11 @@ module	sata_transport #(
 			ign_mm2sgear_bytes_msb, ign_rxgear_bytes_msb,
 			ign_txfifo_fill, ign_rxfifo_fill, ign_s2mm_data
 			};
+	generate if (DW != 32)
+	begin : UNUSED_DW
+		wire	unused_dw;
+		assign	unused_dw = &{ 1'b0, txgear_data[DW-33:0] };
+	end endgenerate
 	// Verilator lint_on  UNUSED
 	// }}}
 endmodule

--- a/rtl/satarx_scrambler.v
+++ b/rtl/satarx_scrambler.v
@@ -135,7 +135,7 @@ module	satarx_scrambler #(
 	end
 	// }}}
 
-	function [32+16-1:0]	scramble(input [15:0] prior);
+	function automatic [32+16-1:0]	scramble(input [15:0] prior);
 		// {{{
 		integer	k;
 		reg	[15:0]	s_fill;

--- a/rtl/satatrn_fsm.v
+++ b/rtl/satatrn_fsm.v
@@ -474,7 +474,7 @@ module	satatrn_fsm #(
 					r_features[7:0] <= i_wb_data[31:24];
 				end
 			// }}}
-			1: begin	// ADDR_LBALO
+			ADDR_LBALO: begin	// ADDR_LBALO
 				// {{{
 				if (i_wb_sel[0])
 					r_lba[7:0] <= i_wb_data[7:0];
@@ -486,7 +486,7 @@ module	satatrn_fsm #(
 					r_device     <= i_wb_data[31:24];
 				end
 				// }}}
-			2: begin	// ADDR_LBAHI
+			ADDR_LBAHI: begin	// ADDR_LBAHI
 				// {{{
 				if (i_wb_sel[0])
 					r_lba[31:24] <= i_wb_data[7:0];
@@ -498,7 +498,7 @@ module	satatrn_fsm #(
 					r_features[15:8] <= i_wb_data[31:24];
 				end
 				// }}}
-			3: begin	// ADDR_COUNT
+			ADDR_COUNT: begin	// ADDR_COUNT
 				// {{{
 				if (i_wb_sel[0])
 					r_count[7:0]  <= i_wb_data[7:0];
@@ -510,16 +510,17 @@ module	satatrn_fsm #(
 					r_control     <= i_wb_data[31:24];
 				end
 				// }}}
-			6: begin // ADDR_LO, r_dma_address
+			ADDR_LO: begin // ADDR_LO, r_dma_address
 				// {{{
 				r_dma_address <= wide_address[ADDRESS_WIDTH-1:0];
 				end
 				// }}}
-			7: begin // ADDR_HI, r_dma_address
+			ADDR_HI: begin // ADDR_HI, r_dma_address
 				// {{{
 				r_dma_address <= wide_address[ADDRESS_WIDTH-1:0];
 				end
 				// }}}
+			default: begin end
 			endcase
 
 			if (known_cmd)
@@ -592,7 +593,9 @@ module	satatrn_fsm #(
 			if (i_s2mm_beat)
 			begin
 				// cmd_length  <= cmd_length - 4;
+				// Verilator lint_off WIDTH
 				o_s2mm_addr <= o_s2mm_addr   + $clog2(DW/8);
+				// Verilator lint_on  WIDTH
 			end
 			o_s2mm_request     <= 1;
 			if (s_pkt_valid && s_sop
@@ -757,15 +760,16 @@ module	satatrn_fsm #(
 	else begin
 		o_wb_data <= 32'h0;
 		case(i_wb_addr)
-		0: o_wb_data <= { r_features[7:0], r_command,
+		ADDR_CMD: o_wb_data <= { r_features[7:0], r_command,
 					r_int, r_dma_fail, 2'b0,
 					r_port, last_fis };
-		1: o_wb_data <= { r_device, r_lba[23:0] };
-		2: o_wb_data <= { r_features[15:8], r_lba[47:24] };
-		3: o_wb_data <= { r_control, r_icc, r_count };
+		ADDR_LBALO: o_wb_data <= { r_device, r_lba[23:0] };
+		ADDR_LBAHI: o_wb_data <= { r_features[15:8], r_lba[47:24] };
+		ADDR_COUNT: o_wb_data <= { r_control, r_icc, r_count };
 		// 5: o_wb_data <= { fsm_state, dma_err, i_link_up, o_link_reset }; // ...
-		6: o_wb_data <= wide_address[31:0];
-		7: o_wb_data <= wide_address[63:32];
+		ADDR_LO: o_wb_data <= wide_address[31:0];
+		ADDR_HI: o_wb_data <= wide_address[63:32];
+		default: begin end
 		endcase
 	end
 	// }}}

--- a/rtl/satatx_scrambler.v
+++ b/rtl/satatx_scrambler.v
@@ -115,7 +115,7 @@ module	satatx_scrambler #(
 	end
 	// }}}
 
-	function [32+16-1:0]	scramble(input [15:0] prior);
+	function automatic [32+16-1:0]	scramble(input [15:0] prior);
 		// {{{
 		integer	k;
 		reg	[15:0]	s_fill;


### PR DESCRIPTION
This fixes a bunch of issues preventing Verilator from building the design at the sata_controller level and below.  With these fixes, the design will (now) build (main and below) in the kimos project.