### PR TITLE
Set Date/Time sim passes

### DIFF
--- a/bench/verilog/mdl_satacmd.v
+++ b/bench/verilog/mdl_satacmd.v
@@ -20,12 +20,17 @@ module mdl_satacmd (
         // }}}
     );
 
-    localparam [127:0] COMMAND_RESPOND = {
-        {8'h00, 8'h77, 4'h0, 4'h0, 8'h27},      // ERROR | STATUS | RIRR | PMPORT | FIS TYPE (0x34)
-        {8'h00, 24'h000000},                    // DEVICE | LBA[23:0]
-        {8'h00, 24'h000000},                    // FEATURES[15:8] | LBA[47:24]
-        {8'h00 ,8'h00, 16'h0000}                // CONTROL | ICC | COUNT[15:0]
-    };
+	// Remember ... the SATA spec is listed with byte 0 in bits [7:0],
+	// but we transmit big-endian, so byte 0 must be placed in the most
+	// significant bits.  This will have the appearance of swapping byte
+	// order in words.
+	localparam [127:0] COMMAND_RESPOND = {
+		// FIS TYPE (0x34) | RIRR,PMPORT | STATUS | ERROR
+		{8'h34, 4'h0, 4'h0, 8'h77, 8'h00 },
+		{8'h00, 24'h000000},		// DEVICE | LBA[23:0]
+		{8'h00, 24'h000000},		// FEATURES[15:8] | LBA[47:24]
+		{8'h00 ,8'h00, 16'h0000}	// CONTROL | ICC | COUNT[15:0]
+	};
 
     reg     known_cmd;
     reg [2:0] cnt;

--- a/bench/verilog/testscript/sata_commands.v
+++ b/bench/verilog/testscript/sata_commands.v
@@ -11,52 +11,17 @@ localparam [127:0] SET_DATE_TIME_EXT_CMD = {
     {8'h00 ,8'h00, 16'h0000}                // CONTROL | ICC | COUNT[15:0]
 };
 
-// task sdio_wait_while_busy;
-// 	reg	[31:0]	read_data;
-// 	reg		prior_interrupt;
-// begin
-
 task testscript; // send_set_date_time_ext;
-    // input [47:0] timestamp;  // Timestamp in milliseconds
+	// input [47:0] timestamp;  // Timestamp in milliseconds
+begin
+	// Initialize command fields
+	// feature = 16'h0000;       // Reserved for SET DATE & TIME EXT
+	// count   = 16'h0000;       // Reserved for this command
+	// lba     = timestamp;      // Timestamp provided as input
+	// device  = 8'h00;          // Typically 0x00 for control commands
+	// command = 8'h77;          // SET DATE & TIME EXT opcode
 
-    reg [7:0] status; // Status output to check command result
-    reg [15:0] feature;  // FEATURE field
-    reg [15:0] count;    // COUNT field
-    reg [47:0] lba;      // LBA field
-    reg [7:0] device;    // DEVICE field
-    reg [7:0] command;   // COMMAND field
-    reg [4:0] result;    // Result from BFM functions
-
-    begin
-        @(posedge wb_clk);
-        while(wb_reset !== 1'b0)
-            @(posedge wb_clk);
-        @(posedge wb_clk);
-
-        // Initialize command fields
-        // feature = 16'h0000;       // Reserved for SET DATE & TIME EXT
-        // count   = 16'h0000;       // Reserved for this command
-        // lba     = timestamp;      // Timestamp provided as input
-        // device  = 8'h00;          // Typically 0x00 for control commands
-        // command = 8'h77;          // SET DATE & TIME EXT opcode
-
-        $display("Sending SET DATE & TIME EXT Command...");
-
-        // Send FEATURE field
-        u_bfm.writeio(ADDR_COUNT, SET_DATE_TIME_EXT_CMD[31:0]);
-        u_bfm.writeio(ADDR_LBAHI, SET_DATE_TIME_EXT_CMD[63:32]);
-        u_bfm.writeio(ADDR_LBALO, SET_DATE_TIME_EXT_CMD[95:64]);
-        u_bfm.write_f(ADDR_CMD, SET_DATE_TIME_EXT_CMD[127:96]);
-
-        // Wait for command completion and check status
-        $display("Waiting for command completion...");
-        wait(sata_int);
-        u_bfm.readio(ADDR_CMD, status);
-
-        if (status == 8'h50)
-            $display("SET DATE & TIME EXT command completed successfully.");
-        else
-            $display("SET DATE & TIME EXT command failed with status: %h", status);
-    end
-endtask
+	$display("Sending SET DATE & TIME EXT Command...");
+	sata_set_time(TIMESTAMP);
+end endtask
 

--- a/bench/verilog/testscript/sata_start.v
+++ b/bench/verilog/testscript/sata_start.v
@@ -1,6 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// Filename:	sata_start.v
+// {{{
+// Project:	A Wishbone SATA controller
+//
+// Purpose:	This module ... doesn't seem to have a purpose.  It isn't
+//		(currently) part of any simulation, and may be removed in the
+//	future.
+//
+// Creator:
+//
+////////////////////////////////////////////////////////////////////////////////
+// }}}
+// Copyright (C) 2025, Gisselquist Technology, LLC
+// {{{
+// This file is part of the WBSATA project.
+//
+// The WBSATA project is a free software (firmware) project: you may
+// redistribute it and/or modify it under the terms of  the GNU General Public
+// License as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTIBILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program.  If not, please see <http://www.gnu.org/licenses/> for a
+// copy.
+// }}}
+// License:	GPL, v3, as defined and found on www.gnu.org,
+// {{{
+//		http://www.gnu.org/licenses/gpl.html
+//
+////////////////////////////////////////////////////////////////////////////////
+//
 `include "../testscript/satalib.v"
-
-
+// }}}
 module sata_soft_reset (
     input wire clk,         // Clock sinyali
     input wire reset,       // Reset sinyali

--- a/bench/verilog/testscript/satalib.v
+++ b/bench/verilog/testscript/satalib.v
@@ -4,7 +4,8 @@
 // {{{
 // Project:	A Wishbone SATA controller
 //
-// Purpose:
+// Purpose:	A library of functions to be used as helpers when writing
+//		test scripts.
 //
 // Creator:
 //
@@ -35,7 +36,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 // }}}
-
 localparam	[ADDRESS_WIDTH-1:0]
                 ADDR_CMD      = SATA_ADDR + 0,
                 ADDR_LBALO    = SATA_ADDR + 4,
@@ -45,41 +45,40 @@ localparam	[ADDRESS_WIDTH-1:0]
                 ADDR_HI       = SATA_ADDR + 28,
                 ADDR_SATAPHY  = DRP_ADDR + 0;
 
-localparam [7:0] FIS_TYPE_REG_H2D  = 8'h27;  // Host to Device Register
-localparam [7:0] FIS_TYPE_REG_D2H  = 8'h34;  // Device to Host Register
-localparam [7:0] FIS_TYPE_DMA_ACT  = 8'h39;  // DMA Activate
-localparam [7:0] FIS_TYPE_PIO      = 8'h5F;  // PIO Setup
-localparam [7:0] FIS_TYPE_DATA     = 8'h46;  // Data FIS
-localparam [7:0] FIS_TYPE_BIST     = 8'h58;  // BIST Activate
-localparam [7:0] FIS_TYPE_SETBITS  = 8'hA1;  // Set Device Bits
-localparam [7:0] FIS_TYPE_VENDOR   = 8'hC7;  // Vendor Specific
+localparam [7:0] FIS_TYPE_REG_H2D  = 8'h27,	// Host to Device Register
+		FIS_TYPE_REG_D2H  = 8'h34,	// Device to Host Register
+		FIS_TYPE_DMA_ACT  = 8'h39,	// DMA Activate
+		FIS_TYPE_PIO      = 8'h5F,	// PIO Setup
+		FIS_TYPE_DATA     = 8'h46,	// Data FIS
+		FIS_TYPE_BIST     = 8'h58,	// BIST Activate
+		FIS_TYPE_SETBITS  = 8'hA1,	// Set Device Bits
+		FIS_TYPE_VENDOR   = 8'hC7;	// Vendor Specific
 
-task send_sata_command(input [7:0] command);
-    begin
-        $display("Sending SATA command: %h", command);
-        // Burada komut gönderim mantığı implement edilir
-    end
-endtask
-
-task send_data(input [31:0] data);
-    begin
-        $display("Sending data: %h", data);
-        // Burada veri gönderim mantığı implement edilir
-    end
-endtask
-
-task receive_data(output [31:0] data);
-    begin
-        $display("Receiving data...");
-        // Burada veri alma mantığı implement edilir
-        data = 32'hDEADBEEF; // Simülasyon için örnek veri
-    end
-endtask
+localparam [7:0] CMD_SET_DATETIME = 8'h77;
 
 task wait_response();
-    begin
-        $display("Waiting for response...");
-        #10;  // Simülasyon için bekleme süresi
-        $display("Response received.");
-    end
-endtask
+begin
+	$display("Waiting for response...");
+	// #10;  // Simülasyon için bekleme süresi
+	wait(sata_int);
+	$display("Response received.");
+end endtask
+
+task	sata_set_time(input [47:0] timestamp);
+	reg	[31:0]	status;
+begin
+	u_bfm.writeio(ADDR_COUNT, 32'h0);
+	u_bfm.writeio(ADDR_LBAHI, { 8'h0, timestamp[47:24] });
+	u_bfm.writeio(ADDR_LBALO, { 8'h0, timestamp[23: 0] });
+	u_bfm.writeio(ADDR_CMD,   { 8'h0, CMD_SET_DATETIME, 8'h80,
+			FIS_TYPE_REG_H2D });
+
+	wait(sata_int);
+	u_bfm.readio(ADDR_CMD, status);
+
+	if (status !== 32'h00_77_00_34)
+	begin
+		error_flag = 1'b1;
+		$display("SET DATE & TIME EXT command failed with status 0x%08x", status);
+	end
+end endtask

--- a/bench/verilog/wb_bfm.v
+++ b/bench/verilog/wb_bfm.v
@@ -166,7 +166,8 @@ module	wb_bfm #(
 			if (o_wb_cyc && i_wb_err)
 				err_flag <= 1'b1;
 		end wait(!i_clk);
-		while(!err_flag && o_wb_cyc);
+
+		while(!err_flag && o_wb_cyc)
 		begin
 			@(posedge i_clk)
 			begin

--- a/rtl/sata_link.v
+++ b/rtl/sata_link.v
@@ -130,9 +130,8 @@ module	sata_link #(
 
 	// 1. Remove any received continue and align primitives
 	// {{{
-	satalnk_rmcont #(
-		.P_CONT(P_CONT), .P_ALIGN(P_ALIGN)
-	) rm_align (
+	satalnk_rmcont
+	rm_align (
 		.i_clk(i_rx_clk), .i_reset(!rx_reset_n),
 		//
 		.i_valid(i_rx_valid), .i_primitive(i_rx_data[32]),


### PR DESCRIPTION
- All primitives removed between P_CONT and next (Makes it easier to cross clock domains if necessary) RMCONT primitives now defined in sata_primitives.vh, rather than in parameters
- FIX: Endless loop in wb_bfm
- FIX: mdl_satacmd now returns a REG_TO_HOST_FIS Also swaps byte order, to match the interface
- FIX: Sata transport layer now recognizes returns in their proper byte order
- Set date/time command moved to the test library, satalib