### PR TITLE
Fixed issue with the BWRAP proof -- should work now

### DIFF
--- a/bench/cpp/tb_sata.cpp
+++ b/bench/cpp/tb_sata.cpp
@@ -583,8 +583,12 @@ int	main(int argc, char **argv) {
 	success = tb.dma_test(test_lba, test_count, dma_addr);
 	if (success)
 		printf("DMA TEST SUMMARY: SUCCESS!\n");
-	else
+	else {
 		printf("DMA TEST SUMMARY: FAILED!\n");
+
+		// Exit early, so we can *see* the failed exit status
+		exit(EXIT_FAILURE);
+	}
 
 	// Wait between tests
 	tb.wait(1000);
@@ -594,8 +598,13 @@ int	main(int argc, char **argv) {
 	success = tb.pio_test(test_lba + SATA_SECTOR_SIZE, test_count, 0); // Use different LBA
 	if (success)
 		printf("PIO TEST SUMMARY: SUCCESS!\n");
-	else
+	else {
 		printf("PIO TEST SUMMARY: FAILED!\n");
+
+		// Exit early, so we can *see* the failed exit status
+		exit(EXIT_FAILURE);
+	}
+
 
 	tb.wait(1000);
 		

--- a/bench/formal/Makefile
+++ b/bench/formal/Makefile
@@ -190,7 +190,7 @@ $(PEXTEND)_cvr/PASS: $(PEXTEND).sby $(RTL)/$(PEXTEND).v
 ## {{{
 bwrap: $(BWRAP)
 $(BWRAP): $(BWRAP)_prf/PASS
-$(BWRAP)_prf/PASS: ## $(BWRAP).sby $(BWRAP).v ../verilog/satatb_8b10b.v ../verilog/satatb_10b8b.v
+$(BWRAP)_prf/PASS: $(BWRAP).sby $(BWRAP).v ../verilog/mdl_s8b10b.v ../verilog/mdl_s10b8b.v
 	$(NOJOBSERVER) sby $(SBYFLAGS) $(BWRAP).sby prf
 ## }}}
 

--- a/bench/formal/genreport.pl
+++ b/bench/formal/genreport.pl
@@ -181,6 +181,8 @@ sub getstatus($) {
 			# print "<TR><TD>ERROR match</TD></TR>\n";
 		} if ($line =~ /terminating process/) {
 			$terminated = 1;
+		} if ($line =~ /engine.*induction:.*Trying in/) {
+			$terminated = 0;
 		} if ($line =~ /Checking cover/) {
 			$cvr = 1;
 		} if ($line =~ /engine_\d.induction/) {

--- a/bench/formal/report.html
+++ b/bench/formal/report.html
@@ -1,7 +1,7 @@
 <HTML><HEAD><TITLE>Formal Verification Report</TITLE></HEAD>
 <BODY>
 <H1 align=center>SATA Controller Formal Verification Report</H1>
-<H2 align=center>20250502</H2>
+<H2 align=center>20250609</H2>
 <TABLE border align=center>
 <TR><TH>Status</TH><TH>Component</TD><TH>Proof</TH><TH>Component description</TH></TR>
 <TR></TR>

--- a/bench/formal/satatb_bwrap.sby
+++ b/bench/formal/satatb_bwrap.sby
@@ -12,8 +12,8 @@ smtbmc
 
 [script]
 read -formal satatb_bwrap.v
-read -formal satatb_8b10b.v
-read -formal satatb_10b8b.v
+read -formal mdl_s8b10b.v
+read -formal mdl_s10b8b.v
 --pycode-begin--
 cmd = "hierarchy -top satatb_bwrap"
 output(cmd)
@@ -22,5 +22,5 @@ prep -top satatb_bwrap
 
 [files]
 satatb_bwrap.v
-../verilog/satatb_8b10b.v
-../verilog/satatb_10b8b.v
+../verilog/mdl_s8b10b.v
+../verilog/mdl_s10b8b.v

--- a/bench/formal/satatb_bwrap.v
+++ b/bench/formal/satatb_bwrap.v
@@ -45,13 +45,13 @@ module	satatb_bwrap (
 	wire		valid_input;
 	wire	[10:0]	w_data;
 
-	satatb_8b10b
+	mdl_s8b10b
 	u_8b10b (
 		.S_DATA(i_data),
 		.M_DATA(w_data)
 	);
 
-	satatb_10b8b
+	mdl_s10b8b
 	u_10b8b (
 		.S_DATA(w_data),
 		.M_DATA(o_data)


### PR DESCRIPTION
The `satatb_bwrap.sby` proof in bench/formal wasn't working due to outdated names for the 8b10b encoder and the 10b8b decoder.  These names have now been updated, and the proof passes.

Indeed, all proofs have passed locally save the framer proof which can (according to my notes) take up to 5hrs to complete.

Dan